### PR TITLE
fix: refine invites schema

### DIFF
--- a/supabase_schema_chores.sql
+++ b/supabase_schema_chores.sql
@@ -38,6 +38,24 @@ CREATE TABLE IF NOT EXISTS public.chore_completions (
   notes text
 );
 
+-- Invites table - manage invites for family members
+CREATE TABLE IF NOT EXISTS public.invites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_id uuid NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  email text,
+  role text NOT NULL DEFAULT 'member',
+  created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  token_hash text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz,
+  accepted_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  accepted_at timestamptz,
+  revoked_at timestamptz,
+  UNIQUE (family_id, email),
+  UNIQUE (token_hash)
+);
+
 -- =====================================================
 -- INDEXES FOR PERFORMANCE
 -- =====================================================
@@ -56,6 +74,11 @@ CREATE INDEX IF NOT EXISTS idx_chore_assignments_assigned_by ON public.chore_ass
 CREATE INDEX IF NOT EXISTS idx_chore_completions_assignment ON public.chore_completions (assignment_id);
 CREATE INDEX IF NOT EXISTS idx_chore_completions_completed_by ON public.chore_completions (completed_by);
 CREATE INDEX IF NOT EXISTS idx_chore_completions_date_desc ON public.chore_completions (completed_at DESC);
+
+-- Invites table indexes
+CREATE INDEX IF NOT EXISTS idx_invites_family_id ON public.invites (family_id);
+CREATE INDEX IF NOT EXISTS idx_invites_email ON public.invites (email);
+CREATE INDEX IF NOT EXISTS idx_invites_token_hash ON public.invites (token_hash);
 
 -- =====================================================
 -- TRIGGERS
@@ -77,6 +100,13 @@ CREATE TRIGGER update_chores_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+-- Trigger for invites table
+DROP TRIGGER IF EXISTS update_invites_updated_at ON public.invites;
+CREATE TRIGGER update_invites_updated_at
+  BEFORE UPDATE ON public.invites
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
 -- =====================================================
 -- ROW LEVEL SECURITY (RLS) POLICIES
 -- =====================================================
@@ -87,6 +117,7 @@ ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.chores ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.chore_assignments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.chore_completions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.invites ENABLE ROW LEVEL SECURITY;
 
 -- =====================================================
 -- FAMILIES RLS POLICIES
@@ -371,6 +402,63 @@ CREATE POLICY "completions_insert_own" ON public.chore_completions
   );
 
 -- =====================================================
+-- INVITES RLS POLICIES
+-- =====================================================
+
+-- Admins can read invites within their family
+CREATE POLICY "invites_select_admin" ON public.invites
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'admin'
+        AND p.family_id = invites.family_id
+    )
+  );
+
+-- Admins can create invites within their family
+CREATE POLICY "invites_insert_admin" ON public.invites
+  FOR INSERT WITH CHECK (
+    created_by = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'admin'
+        AND p.family_id = invites.family_id
+    )
+  );
+
+-- Admins can update invites within their family
+CREATE POLICY "invites_update_admin" ON public.invites
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'admin'
+        AND p.family_id = invites.family_id
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'admin'
+        AND p.family_id = invites.family_id
+    )
+  );
+
+-- Admins can delete invites within their family
+CREATE POLICY "invites_delete_admin" ON public.invites
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'admin'
+        AND p.family_id = invites.family_id
+    )
+  );
+
+-- =====================================================
 -- HELPFUL VIEWS FOR POINTS TRACKING
 -- =====================================================
 
@@ -433,5 +521,6 @@ GRANT ALL ON ALL VIEWS IN SCHEMA public TO authenticated;
 COMMENT ON TABLE public.chores IS 'Core chore definitions that can be assigned to family members';
 COMMENT ON TABLE public.chore_assignments IS 'Junction table linking chores to assigned users (supports multi-assignee)';
 COMMENT ON TABLE public.chore_completions IS 'History ledger tracking chore completions with timestamps and notes';
+COMMENT ON TABLE public.invites IS 'Invitations for users to join a family';
 COMMENT ON VIEW public.user_points_summary IS 'Aggregated points summary per user for leaderboards and progress tracking';
 COMMENT ON VIEW public.chore_completion_history IS 'Detailed completion history with chore and user information for admin oversight';

--- a/supabase_schema_chores.sql
+++ b/supabase_schema_chores.sql
@@ -455,11 +455,22 @@ CREATE POLICY "invites_update_admin" ON public.invites
     )
   )
   WITH CHECK (
-    EXISTS (
-      SELECT 1 FROM public.profiles p
-      WHERE p.id = auth.uid()
-        AND p.role = 'admin'
-        AND p.family_id = invites.family_id
+    (
+      role_hint = 'admin'
+      AND EXISTS (
+        SELECT 1 FROM public.families f
+        WHERE f.id = invites.family_id
+          AND f.created_by = auth.uid()
+      )
+    )
+    OR (
+      role_hint <> 'admin'
+      AND EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role = 'admin'
+          AND p.family_id = invites.family_id
+      )
     )
   );
 

--- a/supabase_schema_chores.sql
+++ b/supabase_schema_chores.sql
@@ -43,12 +43,14 @@ CREATE TABLE IF NOT EXISTS public.invites (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   family_id uuid NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
   email text,
+  type text NOT NULL DEFAULT 'adult' CHECK (type IN ('adult', 'kid')),
   role text NOT NULL DEFAULT 'member',
+  role_hint text NOT NULL DEFAULT 'member' CHECK (role_hint IN ('admin', 'member', 'child')),
   created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
   token_hash text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
-  expires_at timestamptz,
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '24 hours'),
   accepted_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
   accepted_at timestamptz,
   revoked_at timestamptz,
@@ -79,6 +81,7 @@ CREATE INDEX IF NOT EXISTS idx_chore_completions_date_desc ON public.chore_compl
 CREATE INDEX IF NOT EXISTS idx_invites_family_id ON public.invites (family_id);
 CREATE INDEX IF NOT EXISTS idx_invites_email ON public.invites (email);
 CREATE INDEX IF NOT EXISTS idx_invites_token_hash ON public.invites (token_hash);
+CREATE INDEX IF NOT EXISTS idx_invites_expires_at ON public.invites (expires_at);
 
 -- =====================================================
 -- TRIGGERS
@@ -420,11 +423,24 @@ CREATE POLICY "invites_select_admin" ON public.invites
 CREATE POLICY "invites_insert_admin" ON public.invites
   FOR INSERT WITH CHECK (
     created_by = auth.uid()
-    AND EXISTS (
-      SELECT 1 FROM public.profiles p
-      WHERE p.id = auth.uid()
-        AND p.role = 'admin'
-        AND p.family_id = invites.family_id
+    AND (
+      (
+        role_hint = 'admin'
+        AND EXISTS (
+          SELECT 1 FROM public.families f
+          WHERE f.id = invites.family_id
+            AND f.created_by = auth.uid()
+        )
+      )
+      OR (
+        role_hint <> 'admin'
+        AND EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role = 'admin'
+            AND p.family_id = invites.family_id
+        )
+      )
     )
   );
 


### PR DESCRIPTION
### Motivation
- Align `public.invites` with Issue #20 requirements to avoid storing plaintext tokens, support non-email invites (QR/kid invites), and track acceptance/revocation with timestamps.  
- Replace `invited_by` referencing `auth.users` and the `status` column with profile-based audit fields and timestamp semantics for clearer lifecycle management.  
- Keep changes scoped to `public.invites` only and preserve other tables, views, and policies.

### Description
- Replaced the original `public.invites` definition with a new schema that makes `email` optional, stores `token_hash` (no plaintext `token`), and uses `created_by` as a `REFERENCES public.profiles(id)` column.  
- Added `accepted_by REFERENCES public.profiles(id)`, `accepted_at`, and `revoked_at` timestamps, removed the `status` column, and preserved `UNIQUE (family_id, email)` while adding `UNIQUE (token_hash)`.  
- Added `idx_invites_token_hash` index and kept `idx_invites_email` and `idx_invites_family_id`, added the update trigger `update_invites_updated_at` (reusing `update_updated_at_column()`), and enabled RLS on `public.invites`.  
- Updated the insert policy `invites_insert_admin` to validate `created_by = auth.uid()` and left select/update/delete admin policies scoped to family admins.

### Testing
- No automated tests were run for this schema-only change; validation should be performed by applying `supabase_schema_chores.sql` to a Supabase instance and exercising RLS/insert/update/delete flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f0a94ef083278f1a4de6297013b9)